### PR TITLE
fix: use AUTHOR_EMAIL in CODE_OF_CONDUCT rather than hardcoded email

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -59,7 +59,7 @@ representative at an online or offline event.
 ## Enforcement
 
 Instances of abusive, harassing, or otherwise unacceptable behavior may be
-reported to the community leaders responsible for enforcement at gabrielhansson00@gmail.com.
+reported to the community leaders responsible for enforcement to AUTHOR_EMAIL.
 All complaints will be reviewed and investigated promptly and fairly.
 
 All community leaders are obligated to respect the privacy and security of the
@@ -127,4 +127,3 @@ For answers to common questions about this code of conduct, see the FAQ at
 [Mozilla CoC]: https://github.com/mozilla/diversity
 [FAQ]: https://www.contributor-covenant.org/faq
 [translations]: https://www.contributor-covenant.org/translations
-


### PR DESCRIPTION
You won't get a reason why this is a good idea.